### PR TITLE
Refactor study frontend to use client repositories

### DIFF
--- a/app/study/[id]/page.tsx
+++ b/app/study/[id]/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
 import StudyCompletionOverlay from '@/components/StudyCompletionOverlay'
+import { ApiError } from '@/lib/client/api-client'
+import { deckRepo, reviewRepo, sessionRepo, studyRepo } from '@/lib/client/repositories'
 
 interface Card {
   id: string
@@ -22,6 +24,13 @@ interface StudyStats {
   new: number
   total: number
 }
+
+interface DeckMetadata {
+  title?: string
+  autoRevealSeconds?: number | null
+}
+
+type ReviewActionRating = 'again' | 'hard' | 'good' | 'easy' | 'skip'
 
 export default function StudyPage({ params }: { params: Promise<{ id: string }> }) {
   const resolvedParams = use(params)
@@ -48,36 +57,24 @@ export default function StudyPage({ params }: { params: Promise<{ id: string }> 
 
   const initSession = useCallback(async () => {
     try {
-      const sessionRes = await fetch(`/api/study/${resolvedParams.id}/session`, {
-        method: 'POST',
-      })
-      if (!sessionRes.ok) {
-        if (sessionRes.status === 401) {
-          const returnUrl = encodeURIComponent(`/study/${resolvedParams.id}`)
-          router.push(`/login?returnUrl=${returnUrl}`)
-          return
-        }
-        throw new Error('Failed to create session')
-      }
-      const sessionData = await sessionRes.json()
+      const sessionData = await sessionRepo.create(resolvedParams.id)
       setSessionId(sessionData.session.id)
 
-      const queueRes = await fetch(`/api/study/${resolvedParams.id}/queue`)
-      if (!queueRes.ok) {
-        throw new Error('Failed to fetch study queue')
-      }
-      const queueData = await queueRes.json()
+      const queueData = await studyRepo.getQueue<Card>(resolvedParams.id)
       setCards(queueData.cards)
       setStats(queueData.stats)
       setWarning(queueData.warning)
 
-      // Fetch deck info for title and auto reveal seconds
-      const deckRes = await fetch(`/api/decks/${resolvedParams.id}`)
-      if (deckRes.ok) {
-        const deckData = await deckRes.json()
-        setDeckTitle(deckData.deck.title)
-        setAutoRevealSeconds(deckData.deck.autoRevealSeconds || 5)
-        setTimeRemaining(deckData.deck.autoRevealSeconds || 5)
+      try {
+        const deckData = await deckRepo.get<DeckMetadata>(resolvedParams.id)
+        if (deckData?.deck) {
+          const revealSeconds = deckData.deck.autoRevealSeconds ?? 5
+          setDeckTitle(deckData.deck.title ?? '')
+          setAutoRevealSeconds(revealSeconds)
+          setTimeRemaining(revealSeconds)
+        }
+      } catch (deckError) {
+        console.error('Error fetching deck details:', deckError)
       }
 
       // Start session timer
@@ -91,6 +88,11 @@ export default function StudyPage({ params }: { params: Promise<{ id: string }> 
 
       // Auto-answer timer will be started via useEffect
     } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        const returnUrl = encodeURIComponent(`/study/${resolvedParams.id}`)
+        router.push(`/login?returnUrl=${returnUrl}`)
+        return
+      }
       console.error('Error initializing study session:', error)
     } finally {
       setLoading(false)
@@ -160,7 +162,7 @@ export default function StudyPage({ params }: { params: Promise<{ id: string }> 
     }
   }, [showAnswer, currentIndex, cards.length, handleConfidenceSelect, autoRevealSeconds])
 
-  const handleReview = useCallback(async (rating: 'again' | 'hard' | 'good' | 'easy' | 'skip') => {
+  const handleReview = useCallback(async (rating: ReviewActionRating) => {
     if (!cards[currentIndex]) return
 
     const timeSpent = Math.floor((Date.now() - cardStartTime) / 1000)
@@ -188,33 +190,27 @@ export default function StudyPage({ params }: { params: Promise<{ id: string }> 
 
       // For the last card, we need to wait for both API calls to complete
       // before showing the achievement overlay
-      const promises = []
+      const promises: Promise<unknown>[] = []
 
       if (rating !== 'skip') {
         promises.push(
-          fetch(`/api/study/${resolvedParams.id}/review`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              cardId: currentCardId,
-              rating,
-              sessionId,
-              timeSpent,
-            }),
+          reviewRepo.submit(resolvedParams.id, {
+            cardId: currentCardId,
+            rating,
+            sessionId: sessionId ?? undefined,
+            timeSpent,
           })
         )
       }
 
-      promises.push(
-        fetch(`/api/study/${resolvedParams.id}/session`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
+      if (sessionId) {
+        promises.push(
+          sessionRepo.update(resolvedParams.id, {
             sessionId,
             secondsActive: sessionTime,
-          }),
-        })
-      )
+          })
+        )
+      }
 
       // Wait for all API calls to complete before showing achievement
       Promise.all(promises)
@@ -232,18 +228,16 @@ export default function StudyPage({ params }: { params: Promise<{ id: string }> 
 
     // Send API calls asynchronously (fire and forget) for non-last cards
     if (rating !== 'skip') {
-      fetch(`/api/study/${resolvedParams.id}/review`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+      reviewRepo
+        .submit(resolvedParams.id, {
           cardId: currentCardId,
           rating,
-          sessionId,
+          sessionId: sessionId ?? undefined,
           timeSpent,
-        }),
-      }).catch(error => {
-        console.error('Error recording review:', error)
-      })
+        })
+        .catch(error => {
+          console.error('Error recording review:', error)
+        })
     }
   }, [cards, currentIndex, cardStartTime, resolvedParams.id, sessionId, sessionTime, handleConfidenceSelect, autoRevealSeconds])
 

--- a/components/StudyHeatmap.tsx
+++ b/components/StudyHeatmap.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Tooltip from "./Tooltip";
+import { studyRepo } from "@/lib/client/repositories";
 
 interface HeatmapData {
   [date: string]: {
@@ -17,11 +18,8 @@ export default function StudyHeatmap() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch("/api/study/heatmap");
-        if (res.ok) {
-          const result = await res.json();
-          setData(result.heatmapData);
-        }
+        const result = await studyRepo.getHeatmap();
+        setData(result.heatmapData);
       } catch (error) {
         console.error("Error fetching heatmap data:", error);
       } finally {

--- a/lib/client/api-client.ts
+++ b/lib/client/api-client.ts
@@ -1,0 +1,138 @@
+export interface ApiErrorOptions {
+  data?: unknown
+  cause?: unknown
+}
+
+export class ApiError extends Error {
+  public readonly status: number
+  public readonly data?: unknown
+  public readonly cause?: unknown
+
+  constructor(message: string, status: number, options: ApiErrorOptions = {}) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.data = options.data
+    this.cause = options.cause
+  }
+}
+
+export class ApiClient {
+  constructor(private readonly defaultInit: RequestInit = {}) {}
+
+  async request<T>(input: string, init: RequestInit = {}): Promise<T> {
+    const mergedInit = this.mergeInit(init)
+
+    try {
+      const response = await fetch(input, mergedInit)
+
+      if (response.status === 204) {
+        return undefined as T
+      }
+
+      const contentType = response.headers.get('content-type') || ''
+      let responseData: unknown = null
+
+      if (contentType.includes('application/json')) {
+        try {
+          responseData = await response.json()
+        } catch (error) {
+          throw new ApiError('Failed to parse JSON response', response.status, {
+            cause: error,
+          })
+        }
+      } else {
+        try {
+          responseData = await response.text()
+        } catch (error) {
+          throw new ApiError('Failed to read response', response.status, {
+            cause: error,
+          })
+        }
+      }
+
+      if (!response.ok) {
+        const message =
+          (typeof responseData === 'object' && responseData !== null && 'message' in responseData)
+            ? String((responseData as { message?: string }).message)
+            : response.statusText || 'Request failed'
+
+        throw new ApiError(message, response.status, {
+          data: responseData,
+        })
+      }
+
+      return responseData as T
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error
+      }
+
+      const message = error instanceof Error ? error.message : 'Network request failed'
+      throw new ApiError(message, 0, { cause: error })
+    }
+  }
+
+  get<T>(url: string, init?: RequestInit) {
+    return this.request<T>(url, { ...init, method: 'GET' })
+  }
+
+  post<T>(url: string, body?: unknown, init?: RequestInit) {
+    return this.request<T>(url, this.withJsonBody(init, body, 'POST'))
+  }
+
+  put<T>(url: string, body?: unknown, init?: RequestInit) {
+    return this.request<T>(url, this.withJsonBody(init, body, 'PUT'))
+  }
+
+  patch<T>(url: string, body?: unknown, init?: RequestInit) {
+    return this.request<T>(url, this.withJsonBody(init, body, 'PATCH'))
+  }
+
+  delete<T>(url: string, init?: RequestInit) {
+    return this.request<T>(url, { ...init, method: 'DELETE' })
+  }
+
+  private mergeInit(init: RequestInit): RequestInit {
+    const headers = this.mergeHeaders(this.defaultInit.headers, init.headers)
+
+    return {
+      credentials: 'same-origin',
+      ...this.defaultInit,
+      ...init,
+      headers,
+    }
+  }
+
+  private withJsonBody(init: RequestInit = {}, body: unknown, method: string): RequestInit {
+    const headers = this.mergeHeaders(this.defaultInit.headers, init.headers)
+
+    if (body !== undefined && body !== null && !(body instanceof FormData)) {
+      if (!headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json')
+      }
+
+      return {
+        ...this.mergeInit({ ...init, method, headers }),
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+      }
+    }
+
+    return this.mergeInit({ ...init, method, headers, body: body as BodyInit | null | undefined })
+  }
+
+  private mergeHeaders(...headersList: Array<RequestInit['headers'] | undefined>): Headers {
+    const result = new Headers()
+
+    headersList.forEach(headers => {
+      if (!headers) return
+      new Headers(headers).forEach((value, key) => {
+        result.set(key, value)
+      })
+    })
+
+    return result
+  }
+}
+
+export const apiClient = new ApiClient()

--- a/lib/client/repositories/base-repository.ts
+++ b/lib/client/repositories/base-repository.ts
@@ -1,0 +1,25 @@
+import { ApiClient } from '@/lib/client/api-client'
+
+export abstract class BaseRepository {
+  protected constructor(protected readonly client: ApiClient) {}
+
+  protected get<T>(url: string, init?: RequestInit) {
+    return this.client.get<T>(url, init)
+  }
+
+  protected post<T>(url: string, body?: unknown, init?: RequestInit) {
+    return this.client.post<T>(url, body, init)
+  }
+
+  protected put<T>(url: string, body?: unknown, init?: RequestInit) {
+    return this.client.put<T>(url, body, init)
+  }
+
+  protected patch<T>(url: string, body?: unknown, init?: RequestInit) {
+    return this.client.patch<T>(url, body, init)
+  }
+
+  protected delete<T>(url: string, init?: RequestInit) {
+    return this.client.delete<T>(url, init)
+  }
+}

--- a/lib/client/repositories/deck-repository.ts
+++ b/lib/client/repositories/deck-repository.ts
@@ -1,0 +1,62 @@
+import { apiClient } from '@/lib/client/api-client'
+import { BaseRepository } from './base-repository'
+
+export interface DeckDetails<TDeck = unknown> {
+  deck: TDeck
+  cards?: unknown[]
+}
+
+export interface DeckStats {
+  lastStudyDate: string | null
+  totalSessions: number
+  totalCardsReviewed: number
+  performanceGrade: string | null
+  successRate: number | null
+  reviewCount: number
+  isSessionSpecific: boolean
+  sessionId: string | null
+}
+
+export interface DeckStatsResponse {
+  stats: DeckStats
+}
+
+export class DeckRepository extends BaseRepository {
+  constructor() {
+    super(apiClient)
+  }
+
+  get<TDeck = unknown>(deckId: string) {
+    return this.get<DeckDetails<TDeck>>(`/api/decks/${deckId}`)
+  }
+
+  async getStats(deckId: string, params: { sessionId?: string } = {}) {
+    const searchParams = new URLSearchParams()
+
+    if (params.sessionId) {
+      searchParams.set('sessionId', params.sessionId)
+    }
+
+    const query = searchParams.toString()
+    const result = await this.get<DeckStatsResponse>(
+      `/api/decks/${deckId}/stats${query ? `?${query}` : ''}`
+    )
+
+    const stats = result?.stats ?? ({} as Partial<DeckStats>)
+
+    return {
+      stats: {
+        lastStudyDate: stats.lastStudyDate ?? null,
+        totalSessions: stats.totalSessions ?? 0,
+        totalCardsReviewed: stats.totalCardsReviewed ?? 0,
+        performanceGrade: stats.performanceGrade ?? null,
+        successRate: stats.successRate ?? null,
+        reviewCount: stats.reviewCount ?? 0,
+        isSessionSpecific: stats.isSessionSpecific ?? false,
+        sessionId: stats.sessionId ?? null,
+      },
+    } satisfies DeckStatsResponse
+  }
+}
+
+export const deckRepo = new DeckRepository()

--- a/lib/client/repositories/index.ts
+++ b/lib/client/repositories/index.ts
@@ -1,0 +1,4 @@
+export * from './session-repository'
+export * from './review-repository'
+export * from './study-repository'
+export * from './deck-repository'

--- a/lib/client/repositories/review-repository.ts
+++ b/lib/client/repositories/review-repository.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '@/lib/client/api-client'
+import { BaseRepository } from './base-repository'
+
+export type ReviewRating = 'again' | 'hard' | 'good' | 'easy'
+
+export interface ReviewPayload {
+  cardId: string
+  rating: ReviewRating
+  sessionId?: string | null
+  timeSpent?: number
+}
+
+export interface ReviewResponse {
+  success: boolean
+  nextDue: string
+  interval: number
+}
+
+export class ReviewRepository extends BaseRepository {
+  constructor() {
+    super(apiClient)
+  }
+
+  submit(deckId: string, payload: ReviewPayload) {
+    return this.post<ReviewResponse>(`/api/study/${deckId}/review`, payload)
+  }
+}
+
+export const reviewRepo = new ReviewRepository()

--- a/lib/client/repositories/session-repository.ts
+++ b/lib/client/repositories/session-repository.ts
@@ -1,0 +1,56 @@
+import { apiClient } from '@/lib/client/api-client'
+import { BaseRepository } from './base-repository'
+
+export interface StudySession {
+  id: string
+  deckId: string
+  userId: string
+  startedAt: string
+  endedAt: string | null
+  secondsActive: number | null
+}
+
+export interface StudySessionResponse {
+  session: StudySession
+}
+
+export interface SessionPerformance {
+  sessionId: string
+  startedAt: string
+  endedAt: string | null
+  secondsActive: number
+  totalReviews: number
+  cardsReviewed: number
+  performanceGrade: string | null
+  successRate: number | null
+}
+
+export interface SessionPerformanceResponse {
+  sessionPerformance: SessionPerformance
+}
+
+export interface UpdateSessionPayload {
+  sessionId: string
+  secondsActive: number
+  perfectSession?: boolean
+}
+
+export class SessionRepository extends BaseRepository {
+  constructor() {
+    super(apiClient)
+  }
+
+  create(deckId: string) {
+    return this.post<StudySessionResponse>(`/api/study/${deckId}/session`)
+  }
+
+  update(deckId: string, payload: UpdateSessionPayload) {
+    return this.put<StudySessionResponse>(`/api/study/${deckId}/session`, payload)
+  }
+
+  getPerformance(sessionId: string) {
+    return this.get<SessionPerformanceResponse>(`/api/sessions/${sessionId}/performance`)
+  }
+}
+
+export const sessionRepo = new SessionRepository()

--- a/lib/client/repositories/study-repository.ts
+++ b/lib/client/repositories/study-repository.ts
@@ -1,0 +1,66 @@
+import { apiClient } from '@/lib/client/api-client'
+import { BaseRepository } from './base-repository'
+
+export interface StudyQueueStats {
+  due: number
+  new: number
+  total: number
+}
+
+export interface StudyQueueResponse<TCard = unknown> {
+  cards: TCard[]
+  stats: StudyQueueStats
+  warning: string | null
+}
+
+interface RawStudyQueueResponse<TCard> {
+  cards?: TCard[]
+  stats?: Partial<StudyQueueStats>
+  warning?: string | null
+}
+
+export interface StudyHeatmapResponse {
+  heatmapData: Record<string, { count: number; totalCards: number }>
+}
+
+export class StudyRepository extends BaseRepository {
+  constructor() {
+    super(apiClient)
+  }
+
+  async getQueue<TCard = unknown>(deckId: string, options: { limit?: number } = {}) {
+    const searchParams = new URLSearchParams()
+
+    if (typeof options.limit === 'number') {
+      searchParams.set('limit', options.limit.toString())
+    }
+
+    const query = searchParams.toString()
+    const result = await this.get<RawStudyQueueResponse<TCard>>(
+      `/api/study/${deckId}/queue${query ? `?${query}` : ''}`
+    )
+
+    const cards = result.cards ?? []
+    const stats = result.stats ?? {}
+
+    return {
+      cards,
+      stats: {
+        due: stats.due ?? 0,
+        new: stats.new ?? 0,
+        total: stats.total ?? cards.length,
+      },
+      warning: result.warning ?? null,
+    } satisfies StudyQueueResponse<TCard>
+  }
+
+  async getHeatmap() {
+    const result = await this.get<StudyHeatmapResponse>('/api/study/heatmap')
+
+    return {
+      heatmapData: result?.heatmapData ?? {},
+    }
+  }
+}
+
+export const studyRepo = new StudyRepository()


### PR DESCRIPTION
## Summary
- add a reusable ApiClient and client-side repositories to standardize study API calls
- update the study session page to create reviews and sessions through the new repositories with shared error handling
- switch completion overlays and the study heatmap to use the centralized repositories for their data fetches

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0eb1a050c8328bd3934f1df3f41f4