### PR TITLE
Add dark theme support across the app

### DIFF
--- a/app/apple-icon.svg
+++ b/app/apple-icon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180">
   <defs>
     <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#a78bfa;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:hsl(var(--brand-gradient-start, 239 84% 67%));stop-opacity:1" />
+      <stop offset="100%" style="stop-color:hsl(var(--brand-gradient-end, 262 89% 75%));stop-opacity:1" />
     </linearGradient>
   </defs>
 
@@ -10,7 +10,7 @@
   <rect x="10" y="10" width="160" height="160" rx="32" fill="url(#gradient)" />
 
   <!-- Stylized "O" for Oblivian with card elements -->
-  <g fill="white">
+  <g fill="hsl(var(--overlay-foreground, 210 40% 98%))">
     <!-- Back card -->
     <rect x="50" y="45" width="80" height="100" rx="8" opacity="0.4" transform="rotate(-5 90 95)"/>
 
@@ -21,7 +21,7 @@
     <rect x="50" y="40" width="80" height="100" rx="8" opacity="1"/>
 
     <!-- "O" letter inside the card -->
-    <circle cx="90" cy="90" r="28" fill="url(#gradient)" stroke="white" stroke-width="8"/>
-    <circle cx="90" cy="90" r="16" fill="white"/>
+    <circle cx="90" cy="90" r="28" fill="url(#gradient)" stroke="hsl(var(--overlay-foreground, 210 40% 98%))" stroke-width="8"/>
+    <circle cx="90" cy="90" r="16" fill="hsl(var(--card, 0 0% 100%))"/>
   </g>
 </svg>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,48 +4,70 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    color-scheme: light;
+    --background: 212 33% 97%;
+    --foreground: 222 47% 12%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 47% 12%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
+    --popover-foreground: 222 47% 12%;
+    --primary: 230 83% 64%;
     --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-    --radius: 0.5rem;
+    --secondary: 220 15% 92%;
+    --secondary-foreground: 224 40% 20%;
+    --muted: 220 15% 92%;
+    --muted-foreground: 225 15% 45%;
+    --accent: 228 100% 96%;
+    --accent-foreground: 230 45% 24%;
+    --destructive: 0 75% 55%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 216 19% 88%;
+    --input: 216 19% 88%;
+    --ring: 230 83% 64%;
+    --radius: 0.75rem;
+    --brand-gradient-start: 239 84% 67%;
+    --brand-gradient-end: 262 89% 75%;
+    --legendary-light-start: 45 96% 61%;
+    --legendary-light-mid: 48 93% 82%;
+    --legendary-light-end: 48 94% 90%;
+    --legendary-dark-start: 24 95% 58%;
+    --legendary-dark-mid: 45 96% 61%;
+    --legendary-dark-end: 45 96% 61%;
+    --scrim: 222 47% 12%;
+    --overlay-foreground: 210 40% 98%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    color-scheme: dark;
+    --background: 224 35% 9%;
+    --foreground: 210 40% 96%;
+    --card: 225 32% 14%;
+    --card-foreground: 210 40% 96%;
+    --popover: 225 32% 14%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 222 83% 66%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 224 32% 17%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 224 32% 17%;
+    --muted-foreground: 222 19% 75%;
+    --accent: 230 45% 22%;
+    --accent-foreground: 210 40% 96%;
+    --destructive: 0 80% 60%;
+    --destructive-foreground: 210 40% 96%;
+    --border: 221 39% 18%;
+    --input: 221 39% 18%;
+    --ring: 222 83% 66%;
+    --brand-gradient-start: 239 84% 67%;
+    --brand-gradient-end: 262 89% 75%;
+    --legendary-light-start: 45 96% 61%;
+    --legendary-light-mid: 48 93% 82%;
+    --legendary-light-end: 48 94% 90%;
+    --legendary-dark-start: 24 95% 58%;
+    --legendary-dark-mid: 45 96% 61%;
+    --legendary-dark-end: 45 96% 61%;
+    --scrim: 224 35% 9%;
+    --overlay-foreground: 210 40% 96%;
   }
 }
 
@@ -54,7 +76,69 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased transition-colors duration-300 ease-out;
+  }
+
+  ::selection {
+    background-color: hsl(var(--primary) / 0.25);
+    color: hsl(var(--primary-foreground));
+  }
+}
+
+@layer base {
+  .dark .bg-white,
+  .dark .bg-gray-50 {
+    background-color: hsl(var(--card));
+  }
+
+  .dark .bg-gray-100 {
+    background-color: hsl(var(--muted) / 0.55);
+  }
+
+  .dark .bg-gray-200 {
+    background-color: hsl(var(--muted) / 0.7);
+  }
+
+  .dark .hover\:bg-gray-100:hover {
+    background-color: hsl(var(--muted) / 0.45);
+  }
+
+  .dark .text-gray-900,
+  .dark .text-gray-800,
+  .dark .text-gray-700 {
+    color: hsl(var(--card-foreground));
+  }
+
+  .dark .text-gray-600,
+  .dark .text-gray-500 {
+    color: hsl(var(--muted-foreground));
+  }
+
+  .dark .text-gray-400 {
+    color: hsl(var(--muted-foreground) / 0.7);
+  }
+
+  .dark .text-gray-300 {
+    color: hsl(var(--muted-foreground) / 0.55);
+  }
+
+  .dark .text-gray-200 {
+    color: hsl(var(--muted-foreground) / 0.4);
+  }
+
+  .dark .border-gray-200,
+  .dark .border-gray-300,
+  .dark .divide-gray-200 {
+    border-color: hsl(var(--border));
+  }
+
+  .dark .bg-indigo-50 {
+    background-color: hsl(var(--primary) / 0.18);
+  }
+
+  .dark .bg-gray-900 {
+    background-color: hsl(var(--popover));
+    color: hsl(var(--popover-foreground));
   }
 }
 
@@ -73,7 +157,11 @@
   }
 
   .btn-glass {
-    @apply inline-flex items-center justify-center rounded-lg font-medium transition-colors bg-white/80 backdrop-blur-sm text-indigo-600 border-2 border-indigo-500 hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 shadow-lg;
+    @apply inline-flex items-center justify-center rounded-lg font-medium transition-colors border-2 border-primary/60 bg-card/80 text-primary backdrop-blur-sm hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 shadow-lg;
+  }
+
+  .dark .btn-glass {
+    @apply border-primary/60 bg-card/20 text-primary-foreground hover:bg-primary/30;
   }
 
   /* Card Component */
@@ -83,17 +171,51 @@
 
   /* Card hover gradient */
   .card-hover-gradient {
-    @apply bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50;
+    background-image: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.12),
+      hsl(var(--primary) / 0.08),
+      hsl(var(--accent) / 0.12)
+    );
+  }
+
+  .dark .card-hover-gradient {
+    background-image: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.2),
+      hsl(var(--primary) / 0.18),
+      hsl(var(--accent) / 0.22)
+    );
   }
 
   /* Legendary border effect */
   .legendary-border {
     border: 2px solid transparent;
     background-image:
-      linear-gradient(white, white),
-      linear-gradient(90deg, #fbbf24, #fde68a, #fef3c7, #fde68a, #fbbf24);
+      linear-gradient(hsl(var(--card)), hsl(var(--card))),
+      linear-gradient(
+        90deg,
+        hsl(var(--legendary-light-start)),
+        hsl(var(--legendary-light-mid)),
+        hsl(var(--legendary-light-end)),
+        hsl(var(--legendary-light-mid)),
+        hsl(var(--legendary-light-start))
+      );
     background-origin: border-box;
     background-clip: padding-box, border-box;
+  }
+
+  .dark .legendary-border {
+    background-image:
+      linear-gradient(hsl(var(--card)), hsl(var(--card))),
+      linear-gradient(
+        90deg,
+        hsl(var(--legendary-dark-start)),
+        hsl(var(--legendary-dark-mid)),
+        hsl(var(--legendary-dark-end)),
+        hsl(var(--legendary-dark-mid)),
+        hsl(var(--legendary-dark-start))
+      );
   }
 
   /* Form Components */

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <defs>
     <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#a78bfa;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:hsl(var(--brand-gradient-start, 239 84% 67%));stop-opacity:1" />
+      <stop offset="100%" style="stop-color:hsl(var(--brand-gradient-end, 262 89% 75%));stop-opacity:1" />
     </linearGradient>
   </defs>
 
@@ -10,7 +10,7 @@
   <rect x="2" y="2" width="28" height="28" rx="6" fill="url(#gradient)" />
 
   <!-- Stylized "O" for Oblivian with card elements -->
-  <g fill="white">
+  <g fill="hsl(var(--overlay-foreground, 210 40% 98%))">
     <!-- Back card -->
     <rect x="9" y="8" width="14" height="18" rx="2" opacity="0.4" transform="rotate(-5 16 17)"/>
 
@@ -21,7 +21,7 @@
     <rect x="9" y="7" width="14" height="18" rx="2" opacity="1"/>
 
     <!-- "O" letter inside the card -->
-    <circle cx="16" cy="16" r="5" fill="url(#gradient)" stroke="white" stroke-width="1.5"/>
-    <circle cx="16" cy="16" r="3" fill="white"/>
+    <circle cx="16" cy="16" r="5" fill="url(#gradient)" stroke="hsl(var(--overlay-foreground, 210 40% 98%))" stroke-width="1.5"/>
+    <circle cx="16" cy="16" r="3" fill="hsl(var(--card, 0 0% 100%))"/>
   </g>
 </svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import FloatingThemeToggle from '@/components/FloatingThemeToggle'
 import './globals.css'
 
 const inter = Inter({
@@ -19,15 +22,37 @@ export const viewport = {
   maximumScale: 1,
 }
 
+const themeInitializer = `(() => {
+  try {
+    const stored = window.localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = stored === 'light' || stored === 'dark' ? stored : 'system';
+    const resolved = theme === 'dark' || (theme === 'system' && prefersDark) ? 'dark' : 'light';
+    if (resolved === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  } catch (error) {
+    // Ignore errors: we'll fall back to the default theme during hydration.
+  }
+})();`
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={inter.variable}>
-      <body className="font-sans min-h-screen bg-accent">
-        {children}
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
+      <body className="font-sans min-h-screen bg-background text-foreground transition-colors">
+        <Script id="theme-initializer" strategy="beforeInteractive">
+          {themeInitializer}
+        </Script>
+        <ThemeProvider>
+          <FloatingThemeToggle />
+          {children}
+        </ThemeProvider>
         <Analytics />
       </body>
     </html>

--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import Link from 'next/link'
 import { Home, Trophy, Sparkles, Settings, LogOut, Menu, X } from 'lucide-react'
+import ThemeToggle from './ThemeToggle'
 
 interface AppLayoutProps {
   children: React.ReactNode
@@ -78,8 +79,8 @@ export default function AppLayout({ children }: AppLayoutProps) {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-accent flex items-center justify-center">
-        <p className="text-gray-600">Loading...</p>
+      <div className="min-h-screen bg-background flex items-center justify-center transition-colors">
+        <p className="text-muted-foreground">Loading...</p>
       </div>
     )
   }
@@ -87,8 +88,8 @@ export default function AppLayout({ children }: AppLayoutProps) {
   const isActive = (path: string) => pathname === path
 
   return (
-    <div className="min-h-screen bg-accent">
-      <nav className="bg-white shadow-sm border-b">
+    <div className="min-h-screen bg-gradient-to-b from-background via-background to-background text-foreground transition-colors">
+      <nav className="border-b border-border/60 bg-card/80 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/60 transition-colors">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             {/* Logo and Desktop Menu */}
@@ -97,14 +98,26 @@ export default function AppLayout({ children }: AppLayoutProps) {
                 <svg width="32" height="32" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <defs>
                     <linearGradient id="headerGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" style={{ stopColor: '#6366f1', stopOpacity: 1 }} />
-                      <stop offset="100%" style={{ stopColor: '#a78bfa', stopOpacity: 1 }} />
+                      <stop
+                        offset="0%"
+                        style={{
+                          stopColor: 'hsl(var(--brand-gradient-start, 239 84% 67%))',
+                          stopOpacity: 1,
+                        }}
+                      />
+                      <stop
+                        offset="100%"
+                        style={{
+                          stopColor: 'hsl(var(--brand-gradient-end, 262 89% 75%))',
+                          stopOpacity: 1,
+                        }}
+                      />
                     </linearGradient>
                   </defs>
                   <rect x="40" y="140" width="320" height="200" rx="16" fill="url(#headerGradient)" fillOpacity="0.3" stroke="url(#headerGradient)" strokeWidth="4"/>
                   <rect x="80" y="100" width="320" height="200" rx="16" fill="url(#headerGradient)" fillOpacity="0.5" stroke="url(#headerGradient)" strokeWidth="4"/>
                   <rect x="120" y="60" width="320" height="200" rx="16" fill="url(#headerGradient)" stroke="url(#headerGradient)" strokeWidth="4"/>
-                  <circle cx="280" cy="160" r="60" fill="white" fillOpacity="0.9"/>
+                  <circle cx="280" cy="160" r="60" fill="hsl(var(--card, 0 0% 100%))" fillOpacity="0.9"/>
                   <text x="280" y="185" fontSize="72" fontWeight="bold" fill="url(#headerGradient)" textAnchor="middle" fontFamily="system-ui, -apple-system, sans-serif">O</text>
                 </svg>
                 <span className="hidden sm:inline">Oblivian</span>
@@ -114,7 +127,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
                 <Link
                   href="/dashboard"
                   className={`flex items-center gap-2 hover:text-primary transition-colors ${
-                    isActive('/dashboard') ? 'text-primary font-semibold' : 'text-gray-600'
+                    isActive('/dashboard') ? 'text-primary font-semibold' : 'text-muted-foreground'
                   }`}
                 >
                   <Home className="w-4 h-4" />
@@ -123,7 +136,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
                 <Link
                   href="/achievements"
                   className={`flex items-center gap-2 hover:text-primary transition-colors ${
-                    isActive('/achievements') ? 'text-primary font-semibold' : 'text-gray-600'
+                    isActive('/achievements') ? 'text-primary font-semibold' : 'text-muted-foreground'
                   }`}
                 >
                   <Trophy className="w-4 h-4" />
@@ -131,7 +144,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
                 </Link>
                 <button
                   onClick={handleRandomStudy}
-                  className="flex items-center gap-2 hover:text-primary transition-colors text-gray-600"
+                  className="flex items-center gap-2 text-muted-foreground transition-colors hover:text-primary"
                 >
                   <Sparkles className="w-4 h-4" />
                   Random Deck
@@ -139,7 +152,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
                 <Link
                   href="/settings"
                   className={`flex items-center gap-2 hover:text-primary transition-colors ${
-                    isActive('/settings') ? 'text-primary font-semibold' : 'text-gray-600'
+                    isActive('/settings') ? 'text-primary font-semibold' : 'text-muted-foreground'
                   }`}
                 >
                   <Settings className="w-4 h-4" />
@@ -149,42 +162,46 @@ export default function AppLayout({ children }: AppLayoutProps) {
             </div>
             {/* Desktop User Info */}
             <div className="hidden xl:flex items-center gap-4">
+              <ThemeToggle className="shrink-0" />
               {user && (
-                <span className="text-gray-600">
+                <span className="text-muted-foreground">
                   {user.email}
                 </span>
               )}
               <button
                 onClick={handleLogout}
-                className="flex items-center gap-2 text-gray-600 hover:text-primary transition-colors"
+                className="flex items-center gap-2 text-muted-foreground transition-colors hover:text-primary"
               >
                 <LogOut className="w-4 h-4" />
                 Logout
               </button>
             </div>
             {/* Mobile Menu Button */}
-            <button
-              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="xl:hidden flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-primary hover:bg-gray-100 transition-colors"
-            >
-              {mobileMenuOpen ? (
-                <X className="w-6 h-6" />
-              ) : (
-                <Menu className="w-6 h-6" />
-              )}
-            </button>
+            <div className="flex items-center gap-3 xl:hidden">
+              <ThemeToggle className="shrink-0" />
+              <button
+                onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+                className="flex items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-primary"
+              >
+                {mobileMenuOpen ? (
+                  <X className="w-6 h-6" />
+                ) : (
+                  <Menu className="w-6 h-6" />
+                )}
+              </button>
+            </div>
           </div>
         </div>
 
         {/* Mobile Menu Overlay */}
         {mobileMenuOpen && (
-          <div className="xl:hidden border-t bg-white">
+          <div className="xl:hidden border-t border-border/60 bg-card/90 backdrop-blur supports-[backdrop-filter]:bg-card/70">
             <div className="px-4 py-3 space-y-1">
               <Link
                 href="/dashboard"
                 onClick={() => setMobileMenuOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors ${
-                  isActive('/dashboard') ? 'text-primary font-semibold bg-indigo-50' : 'text-gray-600'
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-muted/60 ${
+                  isActive('/dashboard') ? 'bg-primary/10 font-semibold text-primary' : 'text-muted-foreground'
                 }`}
               >
                 <Home className="w-5 h-5" />
@@ -193,8 +210,8 @@ export default function AppLayout({ children }: AppLayoutProps) {
               <Link
                 href="/achievements"
                 onClick={() => setMobileMenuOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors ${
-                  isActive('/achievements') ? 'text-primary font-semibold bg-indigo-50' : 'text-gray-600'
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-muted/60 ${
+                  isActive('/achievements') ? 'bg-primary/10 font-semibold text-primary' : 'text-muted-foreground'
                 }`}
               >
                 <Trophy className="w-5 h-5" />
@@ -205,7 +222,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
                   handleRandomStudy()
                   setMobileMenuOpen(false)
                 }}
-                className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-600 w-full text-left"
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-muted-foreground transition-colors hover:bg-muted/60"
               >
                 <Sparkles className="w-5 h-5" />
                 Random Deck
@@ -213,16 +230,22 @@ export default function AppLayout({ children }: AppLayoutProps) {
               <Link
                 href="/settings"
                 onClick={() => setMobileMenuOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors ${
-                  isActive('/settings') ? 'text-primary font-semibold bg-indigo-50' : 'text-gray-600'
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-muted/60 ${
+                  isActive('/settings') ? 'bg-primary/10 font-semibold text-primary' : 'text-muted-foreground'
                 }`}
               >
                 <Settings className="w-5 h-5" />
                 Settings
               </Link>
-              <div className="border-t pt-3 mt-3">
+              <div className="border-t border-border/60 pt-3 mt-3">
+                <div className="flex items-center justify-between rounded-lg px-3 py-2">
+                  <span className="text-sm text-muted-foreground">Appearance</span>
+                  <ThemeToggle className="shrink-0" />
+                </div>
+              </div>
+              <div className="border-t border-border/60 pt-3 mt-3">
                 {user && (
-                  <div className="px-3 py-2 text-sm text-gray-600">
+                  <div className="px-3 py-2 text-sm text-muted-foreground">
                     {user.email}
                   </div>
                 )}
@@ -231,7 +254,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
                     handleLogout()
                     setMobileMenuOpen(false)
                   }}
-                  className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-600 w-full text-left"
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-muted-foreground transition-colors hover:bg-muted/60"
                 >
                   <LogOut className="w-5 h-5" />
                   Logout

--- a/components/FloatingThemeToggle.tsx
+++ b/components/FloatingThemeToggle.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import ThemeToggle from './ThemeToggle'
+
+const APP_LAYOUT_PREFIXES = ['/dashboard', '/achievements', '/study', '/settings', '/decks', '/rankings']
+
+export default function FloatingThemeToggle() {
+  const pathname = usePathname()
+  const hideToggle = pathname ? APP_LAYOUT_PREFIXES.some(prefix => pathname.startsWith(prefix)) : false
+
+  if (hideToggle) {
+    return null
+  }
+
+  return (
+    <div className="pointer-events-none fixed right-4 top-4 z-50 flex print:hidden sm:right-6 sm:top-6">
+      <ThemeToggle className="pointer-events-auto" />
+    </div>
+  )
+}

--- a/components/StudyAchievementOverlay.tsx
+++ b/components/StudyAchievementOverlay.tsx
@@ -142,11 +142,13 @@ export function StudyAchievementOverlay({
     <>
       {/* Keyframe animations */}
       <style jsx global>{`
-
-
-
-
-
+        .achievement-overlay {
+          background: radial-gradient(
+            circle at center,
+            hsl(var(--scrim, 222 47% 12%) / 0.82) 0%,
+            hsl(var(--scrim, 222 47% 12%) / 0.94) 100%
+          );
+        }
 
         @keyframes particle-float {
           0% {
@@ -161,10 +163,12 @@ export function StudyAchievementOverlay({
 
         @keyframes achievement-glow {
           0%, 100% {
-            box-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
+            box-shadow: 0 0 20px hsl(var(--overlay-foreground, 210 40% 98%) / 0.3);
           }
           50% {
-            box-shadow: 0 0 40px rgba(255, 255, 255, 0.6), 0 0 80px rgba(255, 255, 255, 0.3);
+            box-shadow:
+              0 0 40px hsl(var(--overlay-foreground, 210 40% 98%) / 0.6),
+              0 0 80px hsl(var(--overlay-foreground, 210 40% 98%) / 0.3);
           }
         }
 
@@ -194,10 +198,7 @@ export function StudyAchievementOverlay({
 
       {/* Full-screen overlay */}
       <div
-        className="fixed inset-0 z-[9999] flex items-center justify-center cursor-pointer"
-        style={{
-          background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.9) 100%)`
-        }}
+        className="achievement-overlay fixed inset-0 z-[9999] flex items-center justify-center cursor-pointer"
         onClick={onComplete}
         title="Click to dismiss"
       >

--- a/components/StudyHeatmap.tsx
+++ b/components/StudyHeatmap.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import clsx from "clsx";
 import { useState, useEffect } from "react";
 import Tooltip from "./Tooltip";
 
@@ -31,13 +32,17 @@ export default function StudyHeatmap() {
     fetchData();
   }, []);
 
+  const intensityLevels = [
+    "bg-muted/70 dark:bg-white/10",
+    "bg-emerald-200/70 dark:bg-emerald-400/25",
+    "bg-emerald-300/80 dark:bg-emerald-400/45",
+    "bg-emerald-400/90 dark:bg-emerald-500/60",
+    "bg-emerald-500 dark:bg-emerald-500",
+  ];
+
   const getIntensity = (count: number) => {
-    if (count === 0) return "bg-gray-100";
-    if (count === 1) return "bg-green-200";
-    if (count === 2) return "bg-green-300";
-    if (count === 3) return "bg-green-400";
-    if (count >= 4) return "bg-green-500";
-    return "bg-gray-100";
+    const index = Math.min(Math.max(Math.floor(count), 0), intensityLevels.length - 1);
+    return intensityLevels[index];
   };
 
   // Generate grid for the last 52 weeks
@@ -169,7 +174,7 @@ export default function StudyHeatmap() {
           Study Activity
         </h2>
         <div className="animate-pulse">
-          <div className="h-32 bg-gray-200 rounded"></div>
+          <div className="h-32 rounded bg-muted/60"></div>
         </div>
       </div>
     );
@@ -177,7 +182,6 @@ export default function StudyHeatmap() {
 
   const weeks = generateGrid();
   const months = monthLabels();
-  const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
   // Calculate total activity
   const totalSessions = Object.values(data).reduce(
@@ -198,11 +202,11 @@ export default function StudyHeatmap() {
       <div className="overflow-x-auto">
         <div className="inline-block relative">
           {/* Month labels */}
-          <div className="relative h-5 mb-1" style={{ marginLeft: '35px' }}>
+          <div className="relative mb-1 h-5" style={{ marginLeft: '35px' }}>
             {months.map((label, i) => (
               <div
                 key={i}
-                className="text-xs text-gray-500 absolute"
+                className="absolute text-xs text-muted-foreground/80"
                 style={{
                   left: `${label.weekIndex * 14}px`,
                 }}
@@ -212,11 +216,10 @@ export default function StudyHeatmap() {
             ))}
           </div>
 
-          <div className="flex gap-[3px] relative">
+          <div className="relative flex gap-[3px]">
             {/* Day labels */}
             <div
-              className="flex flex-col gap-[3px] mr-1 text-xs"
-              style={{ fontSize: "11px", color: "#57606a" }}
+              className="mr-1 flex flex-col gap-[3px] text-[11px] text-muted-foreground/80"
             >
               <div className="h-[11px]"></div>
               <div className="h-[11px] flex items-center pr-1">Mon</div>
@@ -251,11 +254,13 @@ export default function StudyHeatmap() {
                   return (
                     <Tooltip key={dayIndex} content={tooltipContent}>
                       <div
-                        className={`w-[11px] h-[11px] rounded-[2px] ${
+                        className={clsx(
+                          "h-[11px] w-[11px] cursor-pointer rounded-[2px] border border-border/40 transition-colors duration-300",
                           day.isToday
                             ? `${getIntensity(day.count)} ring-1 ring-primary`
-                            : getIntensity(day.count)
-                        } hover:ring-1 hover:ring-gray-400 cursor-pointer`}
+                            : getIntensity(day.count),
+                          "hover:ring-1 hover:ring-primary/40",
+                        )}
                       />
                     </Tooltip>
                   );
@@ -265,22 +270,25 @@ export default function StudyHeatmap() {
           </div>
 
           {/* Legend and totals */}
-          <div className="flex justify-between items-center mt-4">
-            <div className="text-xs text-gray-600">
+          <div className="mt-4 flex items-center justify-between">
+            <div className="text-xs text-muted-foreground">
               <strong>{totalSessions.toLocaleString()}</strong> sessions in the
               last year
-              <span className="text-gray-400 ml-2">·</span>
+              <span className="ml-2 text-muted-foreground/60">·</span>
               <span className="ml-2">
                 {totalCards.toLocaleString()} cards reviewed
               </span>
             </div>
-            <div className="flex items-center gap-2 text-xs text-gray-500">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground/80">
               <span>Less</span>
               <div className="flex gap-[2px]">
                 {[0, 1, 2, 3, 4].map((level) => (
                   <div
                     key={level}
-                    className={`w-[11px] h-[11px] rounded-[2px] ${getIntensity(level)}`}
+                    className={clsx(
+                      "h-[11px] w-[11px] rounded-[2px] border border-border/40",
+                      getIntensity(level),
+                    )}
                   />
                 ))}
               </div>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+
+type Theme = 'light' | 'dark' | 'system'
+
+type ResolvedTheme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  resolvedTheme: ResolvedTheme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+  isMounted: boolean
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+const STORAGE_KEY = 'theme'
+
+const resolveTheme = (theme: Theme, prefersDark: boolean): ResolvedTheme => {
+  if (theme === 'system') {
+    return prefersDark ? 'dark' : 'light'
+  }
+  return theme
+}
+
+const applyThemeClass = (resolved: ResolvedTheme) => {
+  const root = document.documentElement
+  if (resolved === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('system')
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>('light')
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
+      if (stored === 'light' || stored === 'dark' || stored === 'system') {
+        setThemeState(stored)
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('Unable to read stored theme preference', error)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isMounted) return
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+    const updateTheme = (value: Theme) => {
+      const resolved = resolveTheme(value, mediaQuery.matches)
+      setResolvedTheme(resolved)
+      applyThemeClass(resolved)
+    }
+
+    updateTheme(theme)
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (theme === 'system') {
+        const resolved = resolveTheme('system', event.matches)
+        setResolvedTheme(resolved)
+        applyThemeClass(resolved)
+      }
+    }
+
+    if (theme === 'system') {
+      mediaQuery.addEventListener('change', handleChange)
+      return () => mediaQuery.removeEventListener('change', handleChange)
+    }
+  }, [theme, isMounted])
+
+  const setTheme = useCallback((value: Theme) => {
+    setThemeState(value)
+    try {
+      localStorage.setItem(STORAGE_KEY, value)
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('Unable to persist theme preference', error)
+      }
+    }
+    if (typeof window !== 'undefined') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      const resolved = resolveTheme(value, mediaQuery.matches)
+      setResolvedTheme(resolved)
+      applyThemeClass(resolved)
+    }
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setThemeState(prev => {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      const currentResolved = resolveTheme(prev, mediaQuery.matches)
+      const nextResolved: ResolvedTheme = currentResolved === 'dark' ? 'light' : 'dark'
+      const nextTheme: Theme = prev === 'system' ? nextResolved : nextResolved
+      try {
+        localStorage.setItem(STORAGE_KEY, nextTheme)
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn('Unable to persist theme preference', error)
+        }
+      }
+      setResolvedTheme(nextResolved)
+      applyThemeClass(nextResolved)
+      return nextTheme
+    })
+  }, [])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, resolvedTheme, setTheme, toggleTheme, isMounted }),
+    [theme, resolvedTheme, setTheme, toggleTheme, isMounted],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import type { ComponentType } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import clsx from 'clsx'
+import { Check, Moon, Sun, MonitorSmartphone } from 'lucide-react'
+import { useTheme } from './ThemeProvider'
+
+type ThemeOption = {
+  label: string
+  value: 'light' | 'dark' | 'system'
+  icon: ComponentType<{ className?: string }>
+}
+
+const OPTIONS: ThemeOption[] = [
+  { label: 'Light', value: 'light', icon: Sun },
+  { label: 'Dark', value: 'dark', icon: Moon },
+  { label: 'System', value: 'system', icon: MonitorSmartphone },
+]
+
+export default function ThemeToggle({ className }: { className?: string }) {
+  const { theme, resolvedTheme, setTheme, isMounted } = useTheme()
+  const [open, setOpen] = useState(false)
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const handleClick = (event: MouseEvent) => {
+      if (!popoverRef.current) return
+      if (popoverRef.current.contains(event.target as Node)) return
+      setOpen(false)
+    }
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+
+    window.addEventListener('mousedown', handleClick)
+    window.addEventListener('keydown', handleKey)
+    return () => {
+      window.removeEventListener('mousedown', handleClick)
+      window.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  const ActiveIcon = resolvedTheme === 'dark' ? Moon : Sun
+  const resolvedLabel = resolvedTheme === 'dark' ? 'Dark' : 'Light'
+
+  return (
+    <div className={clsx('relative', className)} ref={popoverRef}>
+      <button
+        type="button"
+        onClick={() => setOpen(prev => !prev)}
+        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card/80 backdrop-blur transition-colors hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Toggle theme (currently ${resolvedLabel})`}
+        disabled={!isMounted}
+      >
+        <ActiveIcon className="h-5 w-5" />
+      </button>
+
+      {open && isMounted && (
+        <div
+          className="absolute right-0 z-50 mt-2 w-44 rounded-xl border border-border/80 bg-card p-2 text-sm shadow-lg"
+          role="menu"
+          aria-label="Theme options"
+        >
+          <p className="px-2 pb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Appearance
+          </p>
+          <div className="space-y-1">
+            {OPTIONS.map(option => {
+              const Icon = option.icon
+              const isActive = theme === option.value
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    setTheme(option.value)
+                    setOpen(false)
+                  }}
+                  className={clsx(
+                    'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                    isActive
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground',
+                  )}
+                  role="menuitemradio"
+                  aria-checked={isActive}
+                >
+                  <Icon className="h-4 w-4" />
+                  <span className="flex-1">{option.label}</span>
+                  {isActive && <Check className="h-4 w-4 text-primary" />}
+                </button>
+              )
+            })}
+          </div>
+          <p className="pt-2 text-[11px] leading-tight text-muted-foreground/80">
+            Current:&nbsp;
+            <span className="font-medium text-foreground">{resolvedLabel}</span>
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import clsx from "clsx";
 import { ReactNode, useState, useRef, useEffect } from "react";
 
 interface TooltipProps {
@@ -67,20 +68,23 @@ export default function Tooltip({
       </div>
       {isVisible && (
         <div
-          className={`fixed z-50 bg-gray-900 text-white text-xs rounded-lg px-3 py-2 pointer-events-none shadow-lg ${className}`}
+          className={clsx(
+            'pointer-events-none fixed z-50 rounded-lg border border-border/60 bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg transition-colors',
+            className,
+          )}
           style={{
             left: position.x,
             top: position.y,
-            transform: "translate(-50%, -100%)",
+            transform: 'translate(-50%, -100%)',
           }}
         >
           {content}
           <div
-            className="absolute w-2 h-2 bg-gray-900 rotate-45"
+            className="absolute h-3 w-3 rotate-45 border border-border/60 bg-popover"
             style={{
-              bottom: "-4px",
-              left: "50%",
-              transform: "translateX(-50%)",
+              bottom: '-6px',
+              left: '50%',
+              transform: 'translateX(-50%)',
             }}
           />
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
- refresh the global design tokens and component styles to support a rich dark palette with smooth transitions
- add a reusable ThemeProvider with floating and in-app toggles so users can switch between light, dark, and system modes
- update shared layouts, navigation, tooltips, and the study heatmap to stay legible in both themes
- replace remaining hardcoded gradients and overlay treatments with theme token variants so branding and effects adapt across modes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a4de2ed48328929b648e40000b7d